### PR TITLE
Open house update info on SP for Level 1 2024

### DIFF
--- a/_prospective-students/Open House.md
+++ b/_prospective-students/Open House.md
@@ -15,3 +15,5 @@ description: ""
 |---	|---	|---	|
 | [![](/images/oh2.png)](/chs-experience/)| [![](/images/oh3.png)](/about/Our-CHS-Campus/)|  [![](/images/oh5.png)](/chs-academic-info/)|
 |[![](/images/oh6.png)](/secondary/awards-and-achievements/academic-achievements/)| [![](/images/oh7.png)](/prospective-students/Sec-Admission/direct-school-admission/)| [![](/images/oh8.png)](/secondary/faqs/)|
+
+For the Sec 1 cohort of 2024, they will be enrolled into Singapore - Cambridge Secondary Education Certificate Examinations Programme (SP) instead of the O-Level Programme (OP).


### PR DESCRIPTION
…serId":"1032"}

For the Sec 1 cohort of 2024, they will be enrolled into Singapore - Cambridge Secondary Education Certificate Examinations Programme (SP) instead of the O-Level Programme (OP).